### PR TITLE
Self-sizing cells, mostly

### DIFF
--- a/SelfSizingCollectionView/Base.lproj/Main.storyboard
+++ b/SelfSizingCollectionView/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -42,8 +42,8 @@
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="s8S-UC-gXI">
                                                     <rect key="frame" x="8" y="8" width="359" height="34"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jqB-ux-qQD">
-                                                            <rect key="frame" x="0.0" y="0.0" width="359" height="20.5"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jqB-ux-qQD">
+                                                            <rect key="frame" x="0.0" y="0.0" width="359" height="34"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
@@ -53,7 +53,7 @@
                                                     <constraints>
                                                         <constraint firstAttribute="trailing" secondItem="jqB-ux-qQD" secondAttribute="trailing" id="1ie-ts-Fgt"/>
                                                         <constraint firstItem="jqB-ux-qQD" firstAttribute="top" secondItem="s8S-UC-gXI" secondAttribute="top" id="89O-kf-5GZ"/>
-                                                        <constraint firstAttribute="bottom" secondItem="jqB-ux-qQD" secondAttribute="bottom" priority="249" id="HsV-4R-kbp"/>
+                                                        <constraint firstAttribute="bottom" secondItem="jqB-ux-qQD" secondAttribute="bottom" id="HsV-4R-kbp"/>
                                                         <constraint firstItem="jqB-ux-qQD" firstAttribute="leading" secondItem="s8S-UC-gXI" secondAttribute="leading" id="SoY-6f-QDR"/>
                                                     </constraints>
                                                 </view>

--- a/SelfSizingCollectionView/ViewController.swift
+++ b/SelfSizingCollectionView/ViewController.swift
@@ -23,7 +23,7 @@ class ViewController: UIViewController, UICollectionViewDataSource {
         if #available(iOS 10.0, *) {
             // This causes constaint errors.
 //            collectionViewFlowLayout.itemSize = UICollectionViewFlowLayoutAutomaticSize
-//            collectionViewFlowLayout.estimatedItemSize = CGSize(width: 300, height: 50)
+            collectionViewFlowLayout.estimatedItemSize = CGSize(width: 300, height: 50)
         } else {
             // Fallback on earlier versions
         }
@@ -41,7 +41,9 @@ class ViewController: UIViewController, UICollectionViewDataSource {
         guard let itemCell = cell as? ItemCell else {
             return cell
         }
-
+      
+        itemCell.label.preferredMaxLayoutWidth = collectionView.frame.size.width // tweak as needed
+      
         if indexPath.row % 2 == 0 {
             itemCell.label.text = "blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah"
         } else {


### PR DESCRIPTION
* based on
  https://possiblemobile.com/2016/02/sizing-uicollectionviewcell-fit-multiline-uilabel/
* Bottom constraint on the label set to required (1000) priority
* Set the estimatedItemSize on the flow layout to enable self-sizing cells
* Set the UILabel's preferredMaxLayoutWidth to the width of the
  collectionView